### PR TITLE
Make it easier to specifiy repo and branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: generic
+
+services:
+  - docker
+
+script:
+  - docker build -t test .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,61 @@
+# Build the local source. Not yet optimized but
+# leaves development tools in place.
+FROM r-base
+
+# Manually copy the files relevant for the build.
+# This speeds up the build process while the docker
+# file itself is being developed, but eventually
+# `COPY . /src/` may be preferred.
+COPY R /src/R/
+COPY NAMESPACE /src/
+COPY DESCRIPTION /src/
+COPY man /src/man/
+COPY pom.xml /src/
+COPY tests /src/tests/
+COPY install.R /src/
+
+# Dependencies necessary for install.R
+RUN echo "deb-src http://deb.debian.org/debian testing main" >> /etc/apt/sources.list
+RUN apt-get update && \
+    apt-get -y install libssl-dev curl libxml2-dev libcurl4-openssl-dev
+
+#########################################################################################
+## Necessary for running maven
+## copied from https://hub.docker.com/r/cardcorp/r-java/~/dockerfile/
+##
+## gnupg is needed to add new key
+RUN apt-get update && apt-get install -y gnupg2
+
+## Install Java 
+RUN echo "deb http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" \
+      | tee /etc/apt/sources.list.d/webupd8team-java.list \
+    &&  echo "deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" \
+      | tee -a /etc/apt/sources.list.d/webupd8team-java.list \
+    && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys EEA14886 \
+    && echo "oracle-java8-installer shared/accepted-oracle-license-v1-1 select true" \
+        | /usr/bin/debconf-set-selections \
+    && apt-get update \
+    && apt-get install -y oracle-java8-installer \
+    && update-alternatives --display java \
+    && echo "MAVEN IS NOT IN THE UPSTREAM LIST (JOSH)" \
+    && apt-get install -y maven \ 
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean \
+    && R CMD javareconf
+
+## make sure Java can be found in rApache and other daemons not looking in R ldpaths
+RUN echo "/usr/lib/jvm/java-8-oracle/jre/lib/amd64/server/" > /etc/ld.so.conf.d/rJava.conf
+RUN /sbin/ldconfig
+
+## Install rJava package
+RUN install2.r --error rJava \
+  && rm -rf /tmp/downloaded_packages/ /tmp/*.rds
+##
+##
+#########################################################################################
+
+RUN useradd -ms /bin/bash t && chown -R t /src/
+RUN chown t /usr/local/lib/R/site-library
+USER t
+WORKDIR /src
+RUN Rscript install.R --local

--- a/README.md
+++ b/README.md
@@ -16,12 +16,14 @@ R wrapper around the OMERO Java Gateway, to enable access to OMERO via R using [
 
 ### Automated
 
-* Download and run [install.R](install.R):
+* Download and run [install.R](install.R) script:
   
   ```
-  R CMD BATCH install.R
+  Rscript install.R
   ```
-  (Output will be written to install.Rout, check for errors)
+  
+  You can specify a particular branch to build/install with `--user=[github username] --branch=[branch name]`
+  or perform a local build of the cloned repository with `--local`
 
 ### Manual
 

--- a/install.R
+++ b/install.R
@@ -1,5 +1,5 @@
 # Configuration
-repoURL <- 'https://github.com/ome/rOMERO-gateway.git'
+user <- 'ome'
 branchName <- 'master'
 
 # Install necessary packages
@@ -16,6 +16,7 @@ library(git2r)
 # Clone the git repository
 repoDir <- paste(tempdir(),'romero-gateway', sep="/")
 dir.create(repoDir)
+repoURL <- paste('https://github.com/', user, '/rOMERO-gateway.git', sep = '')
 ret <- git2r::clone(repoURL, branch=branchName, local_path = repoDir)
 if (is.null(ret)) {
   print('Git clone failed.')

--- a/install.R
+++ b/install.R
@@ -5,7 +5,7 @@ branchName <- 'master'
 # -- Don't edit anything below this line --
 
 # Install necessary packages
-libs <- c('rJava', 'devtools', 'git2r', 'testthat', 'roxygen2', 'xml2', 'httr', 'git2r')
+libs <- c('rJava', 'devtools', 'testthat', 'roxygen2', 'xml2', 'httr', 'git2r')
 toInstall <- libs[!(libs %in% installed.packages()[,"Package"])]
 if (length(toInstall) > 0) {
   install.packages(toInstall, repos='http://cran.us.r-project.org')

--- a/install.R
+++ b/install.R
@@ -5,7 +5,7 @@ branchName <- 'master'
 # -- Don't edit anything below this line --
 
 # Install necessary packages
-libs <- c('rJava', 'devtools', 'git2r', 'testthat', 'roxygen2')
+libs <- c('rJava', 'devtools', 'git2r', 'testthat', 'roxygen2', 'xml2', 'httr', 'git2r')
 toInstall <- libs[!(libs %in% installed.packages()[,"Package"])]
 if (length(toInstall) > 0) {
   install.packages(toInstall, repos='http://cran.us.r-project.org')
@@ -51,7 +51,7 @@ if ( ret != 0) {
 }
 
 # Build the romero.gateway package
-packageFile <- devtools::build()
+packageFile <- devtools::build(path = '.')
 if (is.null(packageFile)) {
   print('Build failed.')
   quit(save = 'no', status = 1, runLast = FALSE)

--- a/install.R
+++ b/install.R
@@ -1,6 +1,8 @@
-# Configuration
+# Specifiy a branch to build/install:
 user <- 'ome'
 branchName <- 'master'
+
+# -- Don't edit anything below this line --
 
 # Install necessary packages
 libs <- c('rJava', 'devtools', 'git2r', 'testthat', 'roxygen2')
@@ -13,16 +15,33 @@ if (length(toInstall) > 0) {
 library(devtools)
 library(git2r)
 
-# Clone the git repository
-repoDir <- paste(tempdir(),'romero-gateway', sep="/")
-dir.create(repoDir)
-repoURL <- paste('https://github.com/', user, '/rOMERO-gateway.git', sep = '')
-ret <- git2r::clone(repoURL, branch=branchName, local_path = repoDir)
-if (is.null(ret)) {
-  print('Git clone failed.')
-  quit(save = 'no', status = 1, runLast = FALSE)
+args <- commandArgs(trailingOnly = TRUE)
+localBuild <- FALSE
+if (length(args) > 0) {
+  for (arg in args) {
+    if (arg == '--local')
+      localBuild <- TRUE
+    if (startsWith(arg, '--user='))
+      user <- gsub("--user=", "", arg)
+    if (startsWith(arg, '--branch='))
+      branchName <- gsub("--branch=", "", arg)
+  }
 }
-setwd(repoDir)
+if (!localBuild) {
+  cat('Building romero.gateway based on branch', branchName, 'from user', user, '\n')
+  # Clone the git repository
+  repoDir <- paste(tempdir(),'romero-gateway', sep="/")
+  dir.create(repoDir)
+  repoURL <- paste('https://github.com/', user, '/rOMERO-gateway.git', sep = '')
+  ret <- git2r::clone(repoURL, branch=branchName, local_path = repoDir)
+  if (is.null(ret)) {
+    print('Git clone failed.')
+    quit(save = 'no', status = 1, runLast = FALSE)
+  }
+  setwd(repoDir)
+} else {
+  print('Performing local romero.gateway build')
+}
 
 # Run Maven to fetch the java dependencies
 ret <- system2('mvn', args = c('install'))


### PR DESCRIPTION
# What this PR does

Small change in the `install.R` script, to make PR testing easier (don't have to copy/paste the whole github URL any longer)

For example to test PR #11 , download the`install.R` script, set `user` to `dominikl` and branch to PR the branch, in that case `more_methods_and_tests_2`, then run the script either via `R CMD BATCH install.R` or in the R console with `source('install.R')`
