### PR TITLE
Load hierarchy objects

### DIFF
--- a/R/OMEROServer.R
+++ b/R/OMEROServer.R
@@ -200,10 +200,34 @@ setMethod(f="loadObject",
             gateway <- getGateway(server)
             ctx <- getContext(server)
             browse <- gateway$getFacility(BrowseFacility$class)
-            if (type == 'ImageData')
+            if (type == 'ImageData') {
               object <- browse$getImage(ctx, .jlong(id))
-            else
+            }
+            else if (type == 'ProjectData' || type == 'DatasetData' || type == 'PlateData' || type == 'ScreenData') {
+              ids <- new (ArrayList)
+              ids$add(new (Long, .jlong(id)))
+              if (type == 'ProjectData')
+                clazz <- ProjectData$class
+              if (type == 'DatasetData')
+                clazz <- DatasetData$class
+              if (type == 'ScreenData')
+                clazz <- ScreenData$class
+              if (type == 'PlateData')
+                clazz <- PlateData$class
+              tmp <- browse$getHierarchy(ctx, clazz, ids, .jnull(class = 'omero/sys/Parameters'))
+              it <- tmp$iterator()
+              object <- .jrcall(it, method = "next")
+            }
+            else if(type == 'WellData') {
+              ids <- new (ArrayList)
+              ids$add(new (Long, .jlong(id)))
+              tmp <- browse$getWells(ctx, ids)
+              it <- tmp$iterator()
+              object <- .jrcall(it, method = "next")
+            }
+            else { 
               object <- browse$findObject(ctx, type, .jlong(id))
+            }
             ome <- OMERO(server=server, dataobject=object)
             return(cast(ome))
           }

--- a/tests/testthat/setup.csv
+++ b/tests/testthat/setup.csv
@@ -25,3 +25,4 @@ mapannotation,'testkey:testvalue'
 plateid,1
 platesize,64
 wellsize,4
+wellid,12

--- a/tests/testthat/test-OMEROServer.R
+++ b/tests/testthat/test-OMEROServer.R
@@ -9,6 +9,10 @@ imageID <- strtoi(setup[grep("imageid", setup$Key, ignore.case=T), ]$Value)
 nAnnos <- strtoi(setup[grep("numberofannotations", setup$Key, ignore.case=T), ]$Value)
 
 screenID <- strtoi(setup[grep("screenid", setup$Key, ignore.case=T), ]$Value)
+plateID <- strtoi(setup[grep("plateid", setup$Key, ignore.case=T), ]$Value)
+projectID <- strtoi(setup[grep("projectid", setup$Key, ignore.case=T), ]$Value)
+datasetID <- strtoi(setup[grep("datasetid", setup$Key, ignore.case=T), ]$Value)
+
 mapannotation <- as.character(setup[grep("mapannotation", setup$Key, ignore.case=T), ]$Value)
   
 server <- NULL
@@ -20,12 +24,44 @@ test_that("Test OMEROServer connect",{
   expect_that(s@user$getId(), is_a("numeric"))
 })
 
-test_that("Test OMEROServer loadObject",{
+test_that("Test OMEROServer loadObject Image",{
   image <- loadObject(server, "ImageData", imageID)
   expect_that(image@dataobject$getId(), equals(imageID))
   
   clazz <- class(image)[[1]]
   expect_that(clazz, equals('Image'))
+})
+
+test_that("Test OMEROServer loadObject Screen",{
+  screen <- loadObject(server, "ScreenData", screenID)
+  expect_that(screen@dataobject$getId(), equals(screenID))
+  
+  clazz <- class(screen)[[1]]
+  expect_that(clazz, equals('Screen'))
+})
+
+test_that("Test OMEROServer loadObject Plate",{
+  plate <- loadObject(server, "PlateData", plateID)
+  expect_that(plate@dataobject$getId(), equals(plateID))
+  
+  clazz <- class(plate)[[1]]
+  expect_that(clazz, equals('Plate'))
+})
+
+test_that("Test OMEROServer loadObject Project",{
+  proj <- loadObject(server, "ProjectData", projectID)
+  expect_that(proj@dataobject$getId(), equals(projectID))
+  
+  clazz <- class(proj)[[1]]
+  expect_that(clazz, equals('Project'))
+})
+
+test_that("Test OMEROServer loadObject Dataset",{
+  ds <- loadObject(server, "DatasetData", datasetID)
+  expect_that(ds@dataobject$getId(), equals(datasetID))
+  
+  clazz <- class(ds)[[1]]
+  expect_that(clazz, equals('Dataset'))
 })
 
 test_that("Test OMEROServer getAnnotations",{

--- a/tests/testthat/test-Well.R
+++ b/tests/testthat/test-Well.R
@@ -1,0 +1,20 @@
+setup <- read.csv("setup.csv", comment.char = "#", header = TRUE)
+
+host <- as.character(setup[grep("omero.host", setup$Key, ignore.case=T), ]$Value)
+port <- strtoi(setup[grep("omero.port", setup$Key, ignore.case=T), ]$Value)
+user <- as.character(setup[grep("omero.user", setup$Key, ignore.case=T), ]$Value)
+pass <- as.character(setup[grep("omero.pass", setup$Key, ignore.case=T), ]$Value)
+
+wellID <- strtoi(setup[grep("wellid", setup$Key, ignore.case=T), ]$Value)
+
+server <- OMEROServer(host=host, port=port, username=user, password=pass)
+server <- connect(server)
+
+test_that("Test Well getImages",{
+  well <- loadObject(server, "WellData", wellID)
+  imgs <- getImages(well)
+  expect_that(length(imgs), equals(4))
+  
+  clazz <- class(imgs[[1]])[[1]]
+  expect_that(clazz, equals('Image'))
+})


### PR DESCRIPTION
Where possible, use the gateway facility's `getHierarchy` and `getWells` methods to load objects, so that the objects are properly initiliazed. 

The `getWells` method is only available after https://github.com/openmicroscopy/openmicroscopy/pull/5303 is merged and *released*. Would it make sense to create a `romero-gateway/dev` branch which uses the *OMERO-DEV-merge* artifacts? If not getting new Java gateway features into romero-gateway always has to wait for next OMERO release, @joshmoore @jburel ?

Note: Only last commit is relevant for this PR (builds on top of #17 )