### PR TITLE
Bump OMERO version to 5_4_0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: romero.gateway
 Type: Package
-Version: 5.3.0
+Version: 0.1.0
 OMERO_Version: 5.4.0
-Date: 2017-04-05
+Date: 2017-11-14
 Title: OMERO R Gateway
 Description: R Wrapper around the OMERO Java Gateway, which
   enables access to an OMERO server within R.
@@ -10,8 +10,12 @@ Author: Dominik Lindner
 Maintainer: Dominik Lindner <d.lindner@dundee.ac.uk>
 Authors@R: c(person("Dominik", "Lindner", role = c("aut", "cre", "ctb"),
                  email = "d.lindner@dundee.ac.uk"),
-              person("Jean-Marie", "Burel", role = "ctb",
-                 email = "j.burel@dundee.ac.uk"))
+             person("Jean-Marie", "Burel", role = "ctb",
+                 email = "j.burel@dundee.ac.uk"),
+             person("Josh", "Moore", role = "ctb",
+                 email = "josh@glencoesoftware.com"),
+             person("Balaji", "Ramalingam", role = "ctb",
+                 email = "b.ramalingam@dundee.ac.uk"))
 Depends:
     R (>= 3.1.1),
     rJava (>= 0.9-7),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,7 @@
 Package: romero.gateway
 Type: Package
 Version: 5.3.0
+OMERO_Version: 5.4.0
 Date: 2017-04-05
 Title: OMERO R Gateway
 Description: R Wrapper around the OMERO Java Gateway, which

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -62,6 +62,8 @@
   env$SearchScope <- J("omero.gateway.model.SearchScope")
   env$SearchResultCollection <- J("omero.gateway.model.SearchResultCollection")
   
-  
-  packageStartupMessage("\n*** Welcome to rOMERO ***\n")
+  romeroVersion <- packageVersion("romero.gateway")
+  omeroVersion <- packageDescription("romero.gateway", fields = "OMERO_Version")
+  msg <- paste("\n*** Welcome to rOMERO ", romeroVersion, " (~ OMERO ",omeroVersion,") ***\n", sep="")
+  packageStartupMessage(msg)
 }

--- a/man/getThumbnail-Image-method.Rd
+++ b/man/getThumbnail-Image-method.Rd
@@ -5,10 +5,14 @@
 \alias{getThumbnail,Image-method}
 \title{Get the thumbnail for an Image}
 \usage{
-\S4method{getThumbnail}{Image}(image)
+\S4method{getThumbnail}{Image}(image, width = 96, height = 96)
 }
 \arguments{
 \item{image}{The image}
+
+\item{width}{The width (optional, default = 96)}
+
+\item{height}{The height (optional, default = 96)}
 }
 \value{
 The thumbnail

--- a/man/loadDataframe-OMERO-method.Rd
+++ b/man/loadDataframe-OMERO-method.Rd
@@ -5,12 +5,16 @@
 \alias{loadDataframe,OMERO-method}
 \title{Load a dataframe attached to an OME object}
 \usage{
-\S4method{loadDataframe}{OMERO}(omero, id, rowFrom, rowTo, columns)
+\S4method{loadDataframe}{OMERO}(omero, id, condition, rowFrom, rowTo, columns)
 }
 \arguments{
 \item{omero}{The OME object}
 
 \item{id}{The id of the dataframe}
+
+\item{condition}{Only load rows which match the given condition (in which
+case rowFrom, rowTo and columns parameter will be ignored), for example
+(ColumnXYZ=='abc') (i.e. rows with value abc in the column with name ColumnXYZ)}
 
 \item{rowFrom}{Load data from row}
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,20 +5,20 @@
     <modelVersion>4.0.0</modelVersion>
 
     <properties>
-        <bioformats.version>5.5.2</bioformats.version>
+        <bioformats.version>5.7.1</bioformats.version>
         <ice.version>ice36</ice.version>
     </properties>
 
     <parent>
         <groupId>ome</groupId>
         <artifactId>pom-omero-client</artifactId>
-        <version>5.3.4</version>
+        <version>5.4.0</version>
     </parent>
 
     <groupId>org.openmicroscopy</groupId>
     <artifactId>rOMERO</artifactId>
     <packaging>pom</packaging>
-    <version>5.3.3</version>
+    <version>5.4.0</version>
 
     <name>rOMERO</name>
     <description>OMERO R Gateway</description>

--- a/pom.xml
+++ b/pom.xml
@@ -16,11 +16,11 @@
     </parent>
 
     <groupId>org.openmicroscopy</groupId>
-    <artifactId>rOMERO</artifactId>
+    <artifactId>romero-gateway</artifactId>
     <packaging>pom</packaging>
-    <version>5.4.0</version>
+    <version>0.1.0</version>
 
-    <name>rOMERO</name>
+    <name>rOMERO-gateway</name>
     <description>OMERO R Gateway</description>
 
     <dependencies>


### PR DESCRIPTION
"Hijacked" @bramalingam PR #25 which bumps the OMERO version to 5.4.0 and made some additions, to set the romero-gateway version to 0.1.0 and also print out the romero-gateway and OMERO version with the welcome message when the package is loaded (this will help spotting errors which are simply due to client/server version mismatches).

