### PR TITLE
Install script support versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,5 +58,5 @@ RUN useradd -ms /bin/bash t && chown -R t /src/
 RUN chown t /usr/local/lib/R/site-library
 USER t
 WORKDIR /src
-RUN Rscript install.R --local
-CMD ["/src/tests/runtest"]
+#RUN Rscript install.R --local
+#CMD ["/src/tests/runtest"]

--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ R CMD javareconf
 ```
 
 #### Additional dependencies
-In order to build/install some R packages required by the R gateway, additional system libraries may
+In order to build/install some necessary R packages, additional system libraries may
 have to be installed first. E.g. the R packages `httr` and `xml2` need the development libraries for
-`curl` and `xml2`, so for example on a Debian system you most likely have to install `libcurl4-openssl-dev`
+`curl` and `xml2`, so for example on a Debian system you most likely have to install `libcurl4-dev`
 and `libxml2-dev` first.
 

--- a/README.md
+++ b/README.md
@@ -22,8 +22,7 @@ R wrapper around the OMERO Java Gateway, to enable access to OMERO via R using [
   Rscript install.R
   ```
   
-  You can specify a particular branch to build/install with `--user=[github username] --branch=[branch name]`
-  or perform a local build of the cloned repository with `--local`
+  You can specify a particular branch or version to build/install or perform a local build of the cloned repository. Run `Rscript install.R --help` to see more details.
 
 ### Manual
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ R wrapper around the OMERO Java Gateway, to enable access to OMERO via R using [
 
 ### Automated
 
-* Download and run [install.R](install.R) script:
+* Download and run [install.R](install.R) script (requires Maven and Git):
   
   ```
   Rscript install.R

--- a/README.md
+++ b/README.md
@@ -59,3 +59,10 @@ Before installing the `rJava` package you probably have to set up Java for R fir
 export $JAVA_HOME=[path to JDK/JRE]
 R CMD javareconf
 ```
+
+#### Additional dependencies
+In order to build/install some R packages required by the R gateway, additional system libraries may
+have to be installed first. E.g. the R packages `httr` and `xml2` need the development libraries for
+`curl` and `xml2`, so for example on a Debian system you most likely have to install `libcurl4-openssl-dev`
+and `libxml2-dev` first.
+

--- a/install.R
+++ b/install.R
@@ -1,6 +1,7 @@
 # Specifiy a branch to build/install:
 user <- 'ome'
 branchName <- 'master'
+version <- NULL
 
 # -- Don't edit anything below this line --
 
@@ -19,15 +20,32 @@ args <- commandArgs(trailingOnly = TRUE)
 localBuild <- FALSE
 if (length(args) > 0) {
   for (arg in args) {
+    if (arg == '--help') {
+      cat('\n', 'Downloads, builds and installs the romero-gateway package', '\n', '\n')
+      cat('Options:', '\n', '\n')
+      cat('--local              Build local branch', '\n')
+      cat('--version=[VERSION]  Build a specific version (see github tags), e.g. v0.2.0', '\n', '\n')
+      cat('Specify a user repository and/or branch:', '\n')
+      cat('--user=[USER]        Use forked repository of a certain user (default: ome)', '\n')
+      cat('--branch=[BRANCH]    Use branch within the specified user repository (default: master)', '\n', '\n')
+      cat('When no options are specified the \'master\' branch (i.e. the current development snapshot) https://github.com/ome/rOMERO-gateway/tree/master will used.', '\n', '\n')
+      quit(save = 'no', status = 0, runLast = FALSE)
+    }
     if (arg == '--local')
       localBuild <- TRUE
     if (startsWith(arg, '--user='))
       user <- gsub("--user=", "", arg)
     if (startsWith(arg, '--branch='))
       branchName <- gsub("--branch=", "", arg)
+    if (startsWith(arg, '--version='))
+      version <- gsub("--version=", "", arg)
   }
 }
 if (!localBuild) {
+  if( !is.null(version)) {
+    user <- 'ome'
+    branchName <- 'master'
+  }
   cat('Building romero.gateway based on branch', branchName, 'from user', user, '\n')
   # Clone the git repository
   repoDir <- paste(tempdir(),'romero-gateway', sep="/")
@@ -37,6 +55,15 @@ if (!localBuild) {
   if (is.null(ret)) {
     print('Git clone failed.')
     quit(save = 'no', status = 1, runLast = FALSE)
+  }
+  if( !is.null(version)) {
+    for( tag in tags(ret)) {
+      if (tag@name == version) {
+        print(paste('Checking out version', tag@name))
+        git2r::checkout(tag)
+        break
+      }
+    }
   }
   setwd(repoDir)
 } else {

--- a/install.R
+++ b/install.R
@@ -2,6 +2,7 @@
 user <- 'ome'
 branchName <- 'master'
 version <- NULL
+buildonly <- NULL
 
 # -- Don't edit anything below this line --
 
@@ -24,7 +25,8 @@ if (length(args) > 0) {
       cat('\n', 'Downloads, builds and installs the romero-gateway package', '\n', '\n')
       cat('Options:', '\n', '\n')
       cat('--local              Build local branch', '\n')
-      cat('--version=[VERSION]  Build a specific version (see github tags), e.g. v0.2.0', '\n', '\n')
+      cat('--version=[VERSION]  Build a specific version (see github tags), e.g. v0.2.0', '\n')
+      cat('--buildonly=[PATH]   Directory where the romero.gateway_x.y.z.tar.gz package should be saved (if specified the package is only built, not installed), e. g. ~/ (for the user\'s home directory)', '\n', '\n')
       cat('Specify a user repository and/or branch:', '\n')
       cat('--user=[USER]        Use forked repository of a certain user (default: ome)', '\n')
       cat('--branch=[BRANCH]    Use branch within the specified user repository (default: master)', '\n', '\n')
@@ -39,6 +41,8 @@ if (length(args) > 0) {
       branchName <- gsub("--branch=", "", arg)
     if (startsWith(arg, '--version='))
       version <- gsub("--version=", "", arg)
+    if (startsWith(arg, '--buildonly='))
+      buildonly <- gsub("--buildonly=", "", arg)
   }
 }
 if (!localBuild) {
@@ -82,6 +86,16 @@ packageFile <- devtools::build(path = '.')
 if (is.null(packageFile)) {
   print('Build failed.')
   quit(save = 'no', status = 1, runLast = FALSE)
+}
+
+if (!is.null(buildonly)) {
+  res <- file.copy(packageFile, buildonly)
+  if (res)
+    quit(save = 'no', status = 0, runLast = FALSE)
+  else {
+    print('Copy package failed.')
+    quit(save = 'no', status = 1, runLast = FALSE)
+  }
 }
 
 # Install it

--- a/install.R
+++ b/install.R
@@ -1,4 +1,7 @@
-# Specifiy a branch to build/install:
+# Specifiy a user/branch or version to build/install
+# and/or a path ('buildonly' option) to just save the package
+# without installing it.
+# All these options can also be specified via command line argumnents.
 user <- 'ome'
 branchName <- 'master'
 version <- NULL
@@ -6,17 +9,7 @@ buildonly <- NULL
 
 # -- Don't edit anything below this line --
 
-# Install necessary packages
-libs <- c('rJava', 'devtools', 'testthat', 'roxygen2', 'xml2', 'httr', 'git2r', 'jpeg')
-toInstall <- libs[!(libs %in% installed.packages()[,"Package"])]
-if (length(toInstall) > 0) {
-  install.packages(toInstall, repos='http://cran.us.r-project.org')
-}
-
-# Load packages
-library(devtools)
-library(git2r)
-
+# Check command line options
 args <- commandArgs(trailingOnly = TRUE)
 localBuild <- FALSE
 if (length(args) > 0) {
@@ -45,6 +38,20 @@ if (length(args) > 0) {
       buildonly <- gsub("--buildonly=", "", arg)
   }
 }
+
+# Install necessary packages
+libs <- c('rJava', 'devtools', 'testthat', 'roxygen2', 'xml2', 'httr', 'git2r', 'jpeg')
+toInstall <- libs[!(libs %in% installed.packages()[,"Package"])]
+if (length(toInstall) > 0) {
+  install.packages(toInstall, repos='http://cran.us.r-project.org')
+}
+
+# Load packages
+library(devtools)
+library(git2r)
+
+# Build the package
+
 if (!localBuild) {
   if( !is.null(version)) {
     user <- 'ome'

--- a/install.R
+++ b/install.R
@@ -71,12 +71,18 @@ if (!localBuild) {
     if ( !startsWith(version, 'v')) {
       version <- paste0('v', version)
     }
+    found <- FALSE
     for( tag in tags(ret)) {
       if (tag@name == version) {
         print(paste('Checking out version', tag@name))
         git2r::checkout(tag)
+        found <- TRUE
         break
       }
+    }
+    if ( !found ) {
+      print(paste('Can find version', version))
+      quit(save = 'no', status = 1, runLast = FALSE)
     }
   }
   setwd(repoDir)

--- a/install.R
+++ b/install.R
@@ -68,6 +68,9 @@ if (!localBuild) {
     quit(save = 'no', status = 1, runLast = FALSE)
   }
   if( !is.null(version)) {
+    if ( !startsWith(version, 'v')) {
+      version <- paste0('v', version)
+    }
     for( tag in tags(ret)) {
       if (tag@name == version) {
         print(paste('Checking out version', tag@name))

--- a/install.R
+++ b/install.R
@@ -81,7 +81,7 @@ if (!localBuild) {
       }
     }
     if ( !found ) {
-      print(paste('Can find version', version))
+      print(paste('Cannot find version', version))
       quit(save = 'no', status = 1, runLast = FALSE)
     }
   }


### PR DESCRIPTION
Now that we have proper versioning in place, add a `--version` option to the install script, so that one can build specific versions. Also adds a `--help` parameter which hopefully makes the usage of the script a bit easier.
Additionaly added a `buildonly` option, which skips the install step and only builds the package and copies it to a specified location.

# Test
Download and run the `install.R` script with the various options:
- `Rscript install.R --help` : Should only print out the help text without installing anyting.
- `Rscript install.R --version=v0.2.0 --buildonly=/tmp` : Should build the package `/tmp/romero.gateway_0.2.0.tar.gz` but not install it.
- `Rscript install.R` : Should build and install the package from `ome/master` branch.
- Optional: `Rscript install.R --local`: Should build the locally checked out branch (will only work  if you cloned the repository obviously)

Can be tested on a 'clean' Linux VM with 'R' installed, too (**see modified README for probable additional system dependencies**).