### PR TITLE
Add OMERO_Version to bump-version script

### DIFF
--- a/.omeroci/bump-version
+++ b/.omeroci/bump-version
@@ -5,27 +5,63 @@ from fileinput import input
 from os.path import dirname
 from os.path import join
 from os.path import pardir
-from re import compile
+from datetime import date
 
 desc_file = join(dirname(__file__), pardir, "DESCRIPTION")
 pom_file = join(dirname(__file__), pardir, "pom.xml")
 
+def processDesc(version, omeroversion):
+    today = date.today()
+    try:
+        f = input(files=(desc_file), inplace=1)
+        for line in f:
+            if line.startswith("Date:"):
+                print "Date: %s" % today
+            elif line.startswith("Version:") \
+                    and version is not None:
+                print "Version: %s" % version
+            elif line.startswith("OMERO_Version:") \
+                    and omeroversion is not None:
+                print "OMERO_Version: %s" % omeroversion
+            else:
+		print line,
 
-desc_re = compile("^(Version:\s)\S+(.*)$")
-desc_omero_re = compile("^(OMERO_Version:\s)\S+(.*)$")
-pom_re = compile("^(\s{4}<version.)\S+(</version>.?)$")
+    finally:
+        f.close()
 
+def processPom(version, omeroversion):
+    inVersion = False
+    inOmeroVersion = False
+    try:
+        f = input(files=(pom_file), inplace=1)
+        for line in f:
+            if inVersion and version is not None\
+                    and "version" in line:
+                print "    <version>%s</version>" % version
+                inVersion = False
+            elif inOmeroVersion and omeroversion is not None\
+                    and "version" in line:
+                print "        <version>%s</version>" % omeroversion
+                inOmeroVersion = False
+            elif "pom-omero-client" in line:
+                inOmeroVersion = True
+                print line,
+            elif "romero-gateway" in line:
+                inVersion = True
+                print line,
+            else:
+		print line,
 
-def replace_version(file, re, version):
-    for line in input([file], inplace=1):
-        replacement = r"\g<1>%s\g<2>" % version
-        print re.sub(replacement, line),
+    finally:
+        f.close()
 
 if __name__ == "__main__":
     parser = ArgumentParser()
-    parser.add_argument("version")
-    parser.add_argument("omeroversion")
+    parser.add_argument("-v", nargs='?')
+    parser.add_argument("-o", nargs='?')
     args = parser.parse_args()
-    replace_version(desc_file, desc_re, args.version)
-    replace_version(desc_file, desc_omero_re, args.omeroversion)
-    replace_version(pom_file, pom_re, args.version)
+    if args.v is None and args.o is None:
+        print("Usage: ./bumpversion [-v VERSION] [-o OMERO_VERSION]")
+    else: 
+        processDesc(args.v, args.o)
+        processPom(args.v, args.o)

--- a/.omeroci/bump-version
+++ b/.omeroci/bump-version
@@ -12,6 +12,7 @@ pom_file = join(dirname(__file__), pardir, "pom.xml")
 
 
 desc_re = compile("^(Version:\s)\S+(.*)$")
+desc_omero_re = compile("^(OMERO_Version:\s)\S+(.*)$")
 pom_re = compile("^(\s{4}<version.)\S+(</version>.?)$")
 
 
@@ -23,6 +24,8 @@ def replace_version(file, re, version):
 if __name__ == "__main__":
     parser = ArgumentParser()
     parser.add_argument("version")
+    parser.add_argument("omeroversion")
     args = parser.parse_args()
     replace_version(desc_file, desc_re, args.version)
+    replace_version(desc_file, desc_omero_re, args.omeroversion)
     replace_version(pom_file, pom_re, args.version)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: romero.gateway
 Type: Package
 Version: 0.2.0.9000
-OMERO_Version: 5.4.2
-Date: 2018-01-24
+OMERO_Version: 5.4.3
+Date: 2018-01-29
 Title: OMERO R Gateway
 Description: R Wrapper around the OMERO Java Gateway, which
   enables access to an OMERO server within R.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: romero.gateway
 Type: Package
 Version: 0.2.0.9000
-OMERO_Version: 5.4.0
+OMERO_Version: 5.4.1
 Date: 2017-11-14
 Title: OMERO R Gateway
 Description: R Wrapper around the OMERO Java Gateway, which

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: romero.gateway
 Type: Package
 Version: 0.2.0.9000
-OMERO_Version: 5.4.1
-Date: 2017-11-14
+OMERO_Version: 5.4.2
+Date: 2018-01-24
 Title: OMERO R Gateway
 Description: R Wrapper around the OMERO Java Gateway, which
   enables access to an OMERO server within R.

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,5 +59,6 @@ RUN useradd -ms /bin/bash t && chown -R t /src/
 RUN chown t /usr/local/lib/R/site-library
 USER t
 WORKDIR /src
-#RUN Rscript install.R --local
-#CMD ["/src/tests/runtest"]
+
+RUN Rscript install.R --local
+CMD ["/src/tests/runtest"]

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>ome</groupId>
         <artifactId>pom-omero-client</artifactId>
-        <version>5.4.1</version>
+        <version>5.4.2</version>
     </parent>
 
     <groupId>org.openmicroscopy</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>ome</groupId>
         <artifactId>pom-omero-client</artifactId>
-        <version>5.4.2</version>
+        <version>5.4.3</version>
     </parent>
 
     <groupId>org.openmicroscopy</groupId>


### PR DESCRIPTION
Adds `omeroversion` argument to the `bump-version` script and also changes the OMERO_Version in the `DESCRIPTION` file to the correct `5.4.1` version.

See also https://github.com/ome/rOMERO-gateway/issues/32
