### PR TITLE
Bump version to 0.3.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: romero.gateway
 Type: Package
-Version: 0.2.0.9000
+Version: 0.3.0
 OMERO_Version: 5.4.3
 Date: 2018-01-29
 Title: OMERO R Gateway

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <groupId>org.openmicroscopy</groupId>
     <artifactId>romero-gateway</artifactId>
     <packaging>pom</packaging>
-    <version>0.2.0.9000</version>
+    <version>0.3.0</version>
 
     <name>rOMERO-gateway</name>
     <description>OMERO R Gateway</description>


### PR DESCRIPTION
With all the warnings and issues fixed and pointing to the latest `5.4.3` OMERO release, this would be a good occasion to tag a 'stable' `0.3.0` version of the romero-gateway. 