### PR TITLE
Fix javalog warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,20 +27,76 @@
         <dependency>
             <groupId>omero</groupId>
             <artifactId>blitz</artifactId>
+            <exclusions>
+              <exclusion>
+               <groupId>org.slf4j</groupId>
+               <artifactId>slf4j-log4j12</artifactId>
+              </exclusion>
+              <exclusion> 
+                <groupId>log4j</groupId>
+                <artifactId>log4j</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-classic</artifactId>
+              </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>ome</groupId>
             <artifactId>formats-bsd</artifactId>
+            <exclusions>
+              <exclusion>
+               <groupId>org.slf4j</groupId>
+               <artifactId>slf4j-log4j12</artifactId>
+              </exclusion>
+              <exclusion> 
+                <groupId>log4j</groupId>
+                <artifactId>log4j</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-classic</artifactId>
+              </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>ome</groupId>
             <artifactId>formats-gpl</artifactId>
+            <exclusions>
+              <exclusion>
+               <groupId>org.slf4j</groupId>
+               <artifactId>slf4j-log4j12</artifactId>
+              </exclusion>
+              <exclusion> 
+                <groupId>log4j</groupId>
+                <artifactId>log4j</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-classic</artifactId>
+              </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>ome</groupId>
             <artifactId>bioformats_package</artifactId>
             <version>${bioformats.version}</version>
-        </dependency>
+            <exclusions>
+              <exclusion>
+               <groupId>org.slf4j</groupId>
+               <artifactId>slf4j-log4j12</artifactId>
+              </exclusion>
+              <exclusion> 
+                <groupId>log4j</groupId>
+                <artifactId>log4j</artifactId>
+              </exclusion>
+              <exclusion>
+                <groupId>ch.qos.logback</groupId>
+                <artifactId>logback-classic</artifactId>
+              </exclusion>
+            </exclusions>
+        </dependency> 
     </dependencies>
 
     <repositories>


### PR DESCRIPTION
Just fixes the Log4J warnings (which appeared when you try to connect to a server) by adding various log4j exclusions to the pom.xml.

# Test
**Replicate the issue:**
- Build and install the master branch: `RScript install.R`
- Launch the R console: `R`
- Load library and try to connect to a server (login credentials don't have to be valid)
```
library(romero.gateway)
server <- OMEROServer(username='doesntmatter', password='xxx', host='localhost', port=as.integer(4064))
connect(server)
quit()
```
- You should see a bunch of warnings like `SLF4J: Class path contains multiple SLF4J bindings.`

**Test fix:**
- Build and install this branch: `Rscript install.R --user=dominikl --branch=fix_javalog_warnings`
- Launch the R console: `R`
- Load library and try to connect to a server (login credentials don't have to be valid)
```
library(romero.gateway)
server <- OMEROServer(username='doesntmatter', password='xxx', host='localhost', port=as.integer(4064))
connect(server)
quit()
```
- No SLF4J warnings should appear

