### PR TITLE
Fix install script

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: romero.gateway
 Type: Package
-Version: 0.4.0.9000
+Version: 0.4.1
 OMERO_Version: 5.4.6
-Date: 2018-05-24
+Date: 2018-07-24
 Title: OMERO R Gateway
 Description: R Wrapper around the OMERO Java Gateway, which
   enables access to an OMERO server within R.

--- a/install.R
+++ b/install.R
@@ -73,8 +73,8 @@ if (!localBuild) {
     }
     found <- FALSE
     for( tag in tags(ret)) {
-      if (tag@name == version) {
-        print(paste('Checking out version', tag@name))
+      if (tag$name == version) {
+        print(paste('Checking out version', tag$name))
         git2r::checkout(tag)
         found <- TRUE
         break

--- a/install.R
+++ b/install.R
@@ -50,6 +50,10 @@ if (length(toInstall) > 0) {
 library(devtools)
 library(git2r)
 
+git2rVersion <- packageVersion('git2r')
+git2rVersion <- gsub("\\.", "", git2rVersion)
+git2rVersion <- as.integer(git2rVersion)
+
 # Build the package
 
 if (!localBuild) {
@@ -73,8 +77,14 @@ if (!localBuild) {
     }
     found <- FALSE
     for( tag in tags(ret)) {
-      if (tag$name == version) {
-        print(paste('Checking out version', tag$name))
+      # git2r changed syntax from S4 to S3 from version 0.22.0
+      if (git2rVersion > 210)
+        tagname <- tag$name
+      else
+        tagname <- tag@name
+      
+      if (tagname == version) {
+        print(paste('Checking out version', tagname))
         git2r::checkout(tag)
         found <- TRUE
         break

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <groupId>org.openmicroscopy</groupId>
     <artifactId>romero-gateway</artifactId>
     <packaging>pom</packaging>
-    <version>0.4.0</version>
+    <version>0.4.1</version>
 
     <name>rOMERO-gateway</name>
     <description>OMERO R Gateway</description>


### PR DESCRIPTION
For some reason they changed the syntax of the [git2r](https://cran.r-project.org/web/packages/git2r/index.html) package from S4 to S3, so `tag@name` doesn't work any longer and has to be replaced by `tag$name`.
