### PR TITLE
Update Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,24 @@ Need additionally:
 * R package: [testthat](https://cran.r-project.org/web/packages/testthat/index.html) (optional)
 * [Git](https://git-scm.com/)
 
-
 ## Install the romero.gateway R package
 
-### Windows
+### CRAN (recommended)
+
+Install the package from CRAN:
+```
+  install.packages('romero.gateway')
+```
+
+### From package file
+
+If you need to install an older version of the package, because your OMERO server has an older version.
+
+OMERO version | romero.gateway version
+--- | --- 
+5.4 | all
+
+#### Windows
 
 Download the zip package matching your OMERO server from the [Release page](https://github.com/ome/rOMERO-gateway/releases)
 
@@ -30,7 +44,7 @@ In RStudio "Install Packages" use option "Install from:" "Package Archive File" 
 
 Alternatively: In R console run `install.packages('romero.gateway_x.x.x.zip')`
 
-### Unix / OSX
+#### Unix / OSX
 
 Download the tar.gz package matching your OMERO server from the [Release page](https://github.com/ome/rOMERO-gateway/releases)
 

--- a/README.md
+++ b/README.md
@@ -61,10 +61,11 @@ This allows you to install a custom version or build from a custom branch.
 Use the [install.R](install.R) script:
 
 ```
+  curl -o install.R https://raw.githubusercontent.com/ome/rOMERO-gateway/master/install.R 
   Rscript install.R
 ```
 
-You can specify a particular branch or version to build/install or perform a local build of the cloned repository. Run `Rscript install.R --help` to see more details.
+This will build and install the current master branch by default. But you can specify a particular branch or version to build or perform a local build of the cloned repository. Run `Rscript install.R --help` to see more details.
 
 ### Manually
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ R wrapper around the OMERO Java Gateway, to enable access to OMERO via R using [
 * [Java](http://openjdk.java.net/)
 * R package: [rJava](https://cran.r-project.org/web/packages/rJava/index.html)
 * R package: [jpeg](https://cran.r-project.org/web/packages/jpeg/index.html)
+* R package: [httr](https://cran.r-project.org/web/packages/httr/index.html)
 
 ### Developers
 
@@ -21,33 +22,23 @@ Need additionally:
 
 ## Install the romero.gateway R package
 
-### CRAN (recommended)
-
-Install the package from CRAN:
-```
-  install.packages('romero.gateway')
-```
-
-### From package file
-
-If you need to install an older version of the package because your OMERO server has an older version,
-you can install directly from the package file.
+Download the latest romero.gateway version which is compatible with your OMERO server version from the [Release page](https://github.com/ome/rOMERO-gateway/releases)
 
 OMERO version | romero.gateway version
 --- | --- 
 5.4 | all
 
-#### Windows
+### Windows
 
-Download the zip package matching your OMERO server from the [Release page](https://github.com/ome/rOMERO-gateway/releases)
+Download the zip package.
 
 In RStudio "Install Packages" use option "Install from:" "Package Archive File" and select the romero.gateway zip file.
 
 Alternatively: In R console run `install.packages('romero.gateway_x.x.x.zip')`
 
-#### Unix / OSX
+### Unix / OSX
 
-Download the tar.gz package matching your OMERO server from the [Release page](https://github.com/ome/rOMERO-gateway/releases)
+Download the tar.gz package.
 
 In RStudio "Install Packages" use option "Install from:" "Package Archive File" and select the romero.gateway tar.gz file.
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ Install the package from CRAN:
 
 ### From package file
 
-If you need to install an older version of the package, because your OMERO server has an older version.
+If you need to install an older version of the package because your OMERO server has an older version,
+you can install directly from the package file.
 
 OMERO version | romero.gateway version
 --- | --- 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Download the zip package.
 
 In RStudio "Install Packages" use option "Install from:" "Package Archive File" and select the romero.gateway zip file.
 
-Alternatively: In R console run `install.packages('romero.gateway_x.x.x.zip')`
+Alternatively: In R console run `install.packages("https://github.com/ome/rOMERO-gateway/releases/download/vx.x.x/romero.gateway_x.x.x.zip", repos = NULL)`
 
 ### Unix / OSX
 
@@ -42,7 +42,7 @@ Download the tar.gz package.
 
 In RStudio "Install Packages" use option "Install from:" "Package Archive File" and select the romero.gateway tar.gz file.
 
-Alternatively: In R console run `install.packages('romero.gateway_x.x.x.tar.gz', type = 'source')`
+Alternatively: In R console run `install.packages("https://github.com/ome/rOMERO-gateway/releases/download/vx.x.x/romero.gateway_x.x.x.tar.gz", type='source', repos = NULL)`
 
 See [Tips for Unix users](#tips-for-unix-users) section if you are running into difficulties.
 


### PR DESCRIPTION
As the package was removed from CRAN again, this PR now only updates the Readme to recommend the download/installation from the repository release page.

~~Just adds a section about installing from cran (which should now be the default method).~~

~~Note: Although the package is on cran, we should probably still make it available on the github release page too (*). It doesn't matter now, but with OMERO > 5.4 one might need to be able to get an older version of the package (hence the table OMERO <-> romero.gateway version) And the R `install.packages()` method doesn't support specifying a particular version, it just picks the newest one on cran.~~

*) ~~With that respect, could someone with the right github repository permissions please download the 0.4.4 packages from cran and attach them to the rOMERO-gateway github release page https://github.com/ome/rOMERO-gateway/releases/tag/v0.4.4 please . That's 
Windows: https://cran.r-project.org/bin/windows/contrib/3.6/romero.gateway_0.4.4.zip
Unix/OSX: https://cran.r-project.org/src/contrib/romero.gateway_0.4.4.tar.gz~~
