### PR TITLE
R 3.6 and version bump to 0.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+0.4.5 (May 2019)
+----------------
+
+- improved the download process for the OMERO
+  Java libraries
+- disabled staged install for R 3.6 compatibility
+
 0.4.4 (January 2019)
 --------------------
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: romero.gateway
 Type: Package
-Version: 0.4.4.999
-Date: 2018-12-23
+Version: 0.4.5
+Date: 2019-05-14
 Title: OMERO R Gateway
 Description: R Wrapper around the OMERO Java Gateway, which
   enables access to an OMERO server within R.
@@ -40,3 +40,4 @@ NeedsCompilation: no
 URL: https://github.com/ome/rOMERO-gateway, https://www.openmicroscopy.org
 BugReports: http://qa.openmicroscopy.org.uk
 RoxygenNote: 6.1.1
+StagedInstall: no

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,15 +27,7 @@ RUN apt-get -y install libssl-dev libxml2-dev libcurl4-gnutls-dev
 RUN apt-get update && apt-get install -y gnupg2
 
 ## Install Java 
-RUN echo "deb http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" \
-      | tee /etc/apt/sources.list.d/webupd8team-java.list \
-    &&  echo "deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" \
-      | tee -a /etc/apt/sources.list.d/webupd8team-java.list \
-    && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys EEA14886 \
-    && echo "oracle-java8-installer shared/accepted-oracle-license-v1-1 select true" \
-        | /usr/bin/debconf-set-selections \
-    && apt-get update \
-    && apt-get install -y oracle-java8-installer \
+RUN apt-get install -y openjdk-11-jdk \
     && update-alternatives --display java \
     && echo "MAVEN IS NOT IN THE UPSTREAM LIST (JOSH)" \
     && apt-get install -y maven \ 
@@ -44,7 +36,7 @@ RUN echo "deb http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" \
     && R CMD javareconf
 
 ## make sure Java can be found in rApache and other daemons not looking in R ldpaths
-RUN echo "/usr/lib/jvm/java-8-oracle/jre/lib/amd64/server/" > /etc/ld.so.conf.d/rJava.conf
+RUN echo "/usr/lib/jvm/java-11-openjdk-amd64/" > /etc/ld.so.conf.d/rJava.conf
 RUN /sbin/ldconfig
 
 ## Install rJava package


### PR DESCRIPTION
- Bumps the version to 0.4.5
- Disables the "staged install" (that's needed in order to work with recent R version 3.6)
- Added changes since 0.4.4 to changelog
- Updates Dockerfile to use openjdk instead of oracle
