### PR TITLE
Fix bug in Image.getPixelValues method

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: romero.gateway
 Type: Package
-Version: 0.4.5
+Version: 0.4.5.999
 Date: 2019-05-14
 Title: OMERO R Gateway
 Description: R Wrapper around the OMERO Java Gateway, which

--- a/R/Image.R
+++ b/R/Image.R
@@ -465,18 +465,16 @@ setMethod(
     plane <- fac$getPlane(ctx, pixelsObj, as.integer(z-1), as.integer(t-1), as.integer(c-1))
     jpixels = plane$getPixelValues()
     res <- .jevalArray(jpixels)
-    data <- c()
     width <- length(res)
-    height <- 0
-    for (row in res) {
-      col <- .jevalArray(row)
-      data <- c(data, col)
-      if (height == 0) 
-        height <- length(col)
+    height <- res[[1]]$length
+    pixelArray <- array(NA, dim = c(width,height))
+    
+    for (i in 1:width) {
+      col <- .jevalArray(res[[i]])
+      for (j in 1:height)
+        pixelArray[i,j] <- col[j]
     }
     
-    pixelArray <- array(data, dim=c(width, height))
-    pixelArray <- aperm(pixelArray, c(2,1))
     return(pixelArray)
   }
 )


### PR DESCRIPTION
Fixes a bug in the Image.GetPixelValues method, see https://github.com/idr-contrib/community/issues/16

## Replicate issue:

Checkout the `ome/rOMERO-gateway` master branch. Go to the **jupyter directory** and build the docker image (this by default uses the romero.gateway from ome/master branch, which contains the bug):
`docker build -t romero .`
Run it:
`docker run -it -p 8888:8888 romero`

Create new `OMERO R` notebook with the following code and run it:
```
library(romero.gateway)
library(EBImage)

server <- OMEROServer(host = 'idr.openmicroscopy.org', username='public', password='public', port= as.integer(4064))
server <- connect(server)

imageId <- 273169
image <- loadObject(server, "ImageData", imageId)

pixels <- getPixelValues(image, 1, 1, 1)

eb <- EBImage::Image(data = pixels, colormode = 'Grayscale')
eb <- normalize(eb)
EBImage::display(eb)

disconnect(server)
```
Result: Distorted image will be displayed.

## Test PR:

Rebuild the docker image, now specifying to build the romero.gateway from the branch of this PR:
`docker build -t romero --build-arg ROMERO_BRANCH_USER=dominikl --build-arg ROMERO_BRANCH=fix_getpixelvalues .`

Run it again `docker run -it -p 8888:8888 romero` and run the same R snippet again.
Result: The image will be displayed properly.

