### PR TITLE
5.5 adjustments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+env:
+  - OMERO_SERVER_VERSION=5.5
+
 sudo: required
 
 language: python

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,7 @@ Date: 2019-06-06
 Title: OMERO R Gateway
 Description: R Wrapper around the OMERO Java Gateway, which
   enables access to an OMERO server within R.
-  Supported OMERO version: 5.4 .
+  Supported OMERO version: 5.5 .
 Maintainer: Dominik Lindner <d.lindner@dundee.ac.uk>
 Authors@R: c(person("Dominik", "Lindner", role = c("aut", "cre", "ctb"),
                  email = "d.lindner@dundee.ac.uk"),

--- a/R/OMEROServer.R
+++ b/R/OMEROServer.R
@@ -52,6 +52,8 @@ OMEROServer <- setClass(
 #' @param server The server
 #' @param group The group context (group name)
 #'              (optional, default: user's default group)
+#' @param versioncheck Pass FALSE to deactivate the client/server version
+#'                     compatibility check (optional, default: TRUE)
 #' @return The server in "connected" state (if successful)
 #' @export connect
 #' @exportMethod connect
@@ -60,7 +62,7 @@ OMEROServer <- setClass(
 #' server_connected <- connect(server)
 #' }
 setGeneric(name="connect",
-           def=function(server, group=NA)
+           def=function(server, group=NA, versioncheck=TRUE)
            {
              standardGeneric("connect")
            }
@@ -320,7 +322,7 @@ setGeneric(name="getDatasets",
 #' @exportMethod connect
 setMethod(f="connect",
           signature="OMEROServer",
-          definition=function(server, group)
+          definition=function(server, group, versioncheck)
           {
             log <- new(SimpleLogger)
             gateway <- new (Gateway, log)
@@ -344,7 +346,9 @@ setMethod(f="connect",
             
             lc <- new(LoginCredentials, username, password, hostname, as.integer(portnumber))
             lc$setApplicationName("rOMERO")
-            
+            if (!versioncheck) {
+              .jcall(lc, returnSig = "V", method = 'setCheckVersion', FALSE)
+            }
             user <- gateway$connect(lc)
             
             server@gateway <- gateway

--- a/R/OMEROServer.R
+++ b/R/OMEROServer.R
@@ -62,7 +62,7 @@ OMEROServer <- setClass(
 #' server_connected <- connect(server)
 #' }
 setGeneric(name="connect",
-           def=function(server, group=NA, versioncheck=TRUE)
+           def=function(server, group=NA, versioncheck=FALSE)
            {
              standardGeneric("connect")
            }
@@ -317,8 +317,8 @@ setGeneric(name="getDatasets",
 #' @param server The server
 #' @param group The group context (group name)
 #'              (optional, default: user's default group)
-#' @param versioncheck Pass FALSE to deactivate the client/server version
-#'                     compatibility check (optional, default: TRUE)
+#' @param versioncheck Pass TRUE to deactivate the client/server version
+#'                     compatibility check (optional, default: FALSE)
 #' @return The server in "connected" state (if successful)
 #' @export connect
 #' @exportMethod connect

--- a/R/OMEROServer.R
+++ b/R/OMEROServer.R
@@ -350,7 +350,7 @@ setMethod(f="connect",
               tryCatch({
                 .jcall(lc, returnSig = "V", method = 'setCheckVersion', FALSE)
               }, error = function(e) {
-                warning('Ignoring argument versioncheck. Disabling version check needs OMERO >= 5.5.0.')
+                message('Ignoring argument versioncheck. Disabling version check needs OMERO >= 5.5.0.')
               })
             }
             user <- gateway$connect(lc)

--- a/R/OMEROServer.R
+++ b/R/OMEROServer.R
@@ -317,6 +317,8 @@ setGeneric(name="getDatasets",
 #' @param server The server
 #' @param group The group context (group name)
 #'              (optional, default: user's default group)
+#' @param versioncheck Pass FALSE to deactivate the client/server version
+#'                     compatibility check (optional, default: TRUE)
 #' @return The server in "connected" state (if successful)
 #' @export connect
 #' @exportMethod connect

--- a/R/OMEROServer.R
+++ b/R/OMEROServer.R
@@ -347,7 +347,11 @@ setMethod(f="connect",
             lc <- new(LoginCredentials, username, password, hostname, as.integer(portnumber))
             lc$setApplicationName("rOMERO")
             if (!versioncheck) {
-              .jcall(lc, returnSig = "V", method = 'setCheckVersion', FALSE)
+              tryCatch({
+                .jcall(lc, returnSig = "V", method = 'setCheckVersion', FALSE)
+              }, error = function(e) {
+                warning('Ignoring argument versioncheck. Disabling version check needs OMERO >= 5.5.0.')
+              })
             }
             user <- gateway$connect(lc)
             

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -15,7 +15,7 @@
     dir.create(omeroLibs, recursive = TRUE)
   }
   
-  if (!file.exists(paste(omeroLibs, 'blitz.jar', sep = '/'))) {
+  if (!file.exists(paste(omeroLibs, 'omero-gateway.jar', sep = '/'))) {
     # OMERO java libraries haven't been downloaded yet.
     baseURL <- paste('https://downloads.openmicroscopy.org/latest/omero', omeroVersion, sep = '')
     zipFile <- 'OMERO.java.zip'

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -124,4 +124,7 @@
   env$EllipseData <- J("omero.gateway.model.EllipseData")
   env$RectangleData <- J("omero.gateway.model.RectangleData")
   env$AffineTransform <- J("omero.model.AffineTransformI")
+  
+  msg <- paste("\n*** Welcome to rOMERO ", romeroVersion, " ***\n", sep="")
+  packageStartupMessage(msg)
 }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -124,7 +124,4 @@
   env$EllipseData <- J("omero.gateway.model.EllipseData")
   env$RectangleData <- J("omero.gateway.model.RectangleData")
   env$AffineTransform <- J("omero.model.AffineTransformI")
-  
-  msg <- paste("\n*** Welcome to rOMERO ", romeroVersion, " (~ OMERO ",omeroVersion,") ***\n", sep="")
-  packageStartupMessage(msg)
 }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -15,7 +15,8 @@
     dir.create(omeroLibs, recursive = TRUE)
   }
   
-  if (!file.exists(paste(omeroLibs, 'omero-gateway.jar', sep = '/'))) {
+  if (!(file.exists(paste(omeroLibs, 'blitz.jar', sep = '/')) || 
+        file.exists(paste(omeroLibs, 'omero-gateway.jar', sep = '/')))) {
     # OMERO java libraries haven't been downloaded yet.
     baseURL <- paste('https://downloads.openmicroscopy.org/latest/omero', omeroVersion, sep = '')
     zipFile <- 'OMERO.java.zip'

--- a/man/connect-OMEROServer-method.Rd
+++ b/man/connect-OMEROServer-method.Rd
@@ -6,7 +6,7 @@
 \title{Connect to an OMERO server}
 \usage{
 \S4method{connect}{OMEROServer}(server, group = NA,
-  versioncheck = TRUE)
+  versioncheck = FALSE)
 }
 \arguments{
 \item{server}{The server}
@@ -14,8 +14,8 @@
 \item{group}{The group context (group name)
 (optional, default: user's default group)}
 
-\item{versioncheck}{Pass FALSE to deactivate the client/server version
-compatibility check (optional, default: TRUE)}
+\item{versioncheck}{Pass TRUE to deactivate the client/server version
+compatibility check (optional, default: FALSE)}
 }
 \value{
 The server in "connected" state (if successful)

--- a/man/connect-OMEROServer-method.Rd
+++ b/man/connect-OMEROServer-method.Rd
@@ -5,7 +5,8 @@
 \alias{connect,OMEROServer-method}
 \title{Connect to an OMERO server}
 \usage{
-\S4method{connect}{OMEROServer}(server, group = NA)
+\S4method{connect}{OMEROServer}(server, group = NA,
+  versioncheck = TRUE)
 }
 \arguments{
 \item{server}{The server}

--- a/man/connect-OMEROServer-method.Rd
+++ b/man/connect-OMEROServer-method.Rd
@@ -13,6 +13,9 @@
 
 \item{group}{The group context (group name)
 (optional, default: user's default group)}
+
+\item{versioncheck}{Pass FALSE to deactivate the client/server version
+compatibility check (optional, default: TRUE)}
 }
 \value{
 The server in "connected" state (if successful)

--- a/man/connect.Rd
+++ b/man/connect.Rd
@@ -4,13 +4,16 @@
 \alias{connect}
 \title{Connect to an OMERO server}
 \usage{
-connect(server, group = NA)
+connect(server, group = NA, versioncheck = TRUE)
 }
 \arguments{
 \item{server}{The server}
 
 \item{group}{The group context (group name)
 (optional, default: user's default group)}
+
+\item{versioncheck}{Pass FALSE to deactivate the client/server version
+compatibility check (optional, default: TRUE)}
 }
 \value{
 The server in "connected" state (if successful)

--- a/man/connect.Rd
+++ b/man/connect.Rd
@@ -4,7 +4,7 @@
 \alias{connect}
 \title{Connect to an OMERO server}
 \usage{
-connect(server, group = NA, versioncheck = TRUE)
+connect(server, group = NA, versioncheck = FALSE)
 }
 \arguments{
 \item{server}{The server}


### PR DESCRIPTION
Some adjustments needed for OMERO 5.5.0 .

## Test:
Launch a jupyter docker image **for this PR**, see https://github.com/ome/rOMERO-gateway/tree/master/jupyter .

Then test connection to 5.4 server
```
library(romero.gateway)
server <- OMEROServer(host = 'idr.openmicroscopy.org', username='public', password='public', port= as.integer(4064))
server <- connect(server, versioncheck = FALSE)
server@gateway$getServerVersion()
disconnect(server)
```
Then do the same (but without `versioncheck=FALSE`) for a 5.5 server (e.g eel)


