### PR TITLE
Jupyter docker

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -17,3 +17,4 @@
 ^inst$
 ^java$
 ^CHANGELOG.md$
+^jupyter$

--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ Alternatively: In R console run `install.packages("https://github.com/ome/rOMERO
 
 See [Tips for Unix users](#tips-for-unix-users) section if you are running into difficulties.
 
+### Docker / Jupyter
+
+With [Docker](https://www.docker.com/) and [Jupyter](https://jupyter.org/) there is a quick and easy way to
+get an R OMERO enviroment set up and running in your browser. Ideal to quickly try out some snippets. Go to
+(jupyter)[jupyter] directory and see the instructions there.
+
 ## Usage
 
 * Like any other R package load the package ```library(romero.gateway)```

--- a/jupyter/Dockerfile
+++ b/jupyter/Dockerfile
@@ -23,8 +23,10 @@ USER $NB_UID
 # build/install rOMERO
 ENV _JAVA_OPTIONS="-Xss2560k -Xmx2g"
 RUN cd /opt/romero && \
-    curl -sf https://raw.githubusercontent.com/ome/rOMERO-gateway/master/install.R --output install.R && \
-    bash -c "source activate r-omero && Rscript install.R --version=ROMERO_VERSION --user=$ROMERO_BRANCH_USER --branch=$ROMERO_BRANCH --quiet"
+    curl -sf https://raw.githubusercontent.com/ome/rOMERO-gateway/master/install.R --output install.R
+RUN if [ -z ${ROMERO_VERSION} ]; then \
+    bash -c "source activate r-omero && Rscript /opt/romero/install.R --user=$ROMERO_BRANCH_USER --branch=$ROMERO_BRANCH --quiet"; else \
+    bash -c "source activate r-omero && Rscript /opt/romero/install.R --version=$ROMERO_VERSION --quiet"; fi
 
 ENV OMERO_LIBS_DOWNLOAD=TRUE
 RUN bash -c "source activate r-omero && echo \"library('romero.gateway')\" | R --no-save"

--- a/jupyter/Dockerfile
+++ b/jupyter/Dockerfile
@@ -31,3 +31,6 @@ RUN if [ -z ${ROMERO_VERSION} ]; then \
 
 ENV OMERO_LIBS_DOWNLOAD=TRUE
 RUN bash -c "source activate r-omero && echo \"library('romero.gateway')\" | R --no-save"
+
+COPY --chown=1000:100 Get_Started.ipynb notebooks/
+

--- a/jupyter/Dockerfile
+++ b/jupyter/Dockerfile
@@ -1,0 +1,42 @@
+FROM imagedata/jupyter-docker:0.9.0
+MAINTAINER ome-devel@lists.openmicroscopy.org.uk
+
+# The branch to build the romero.gateway from
+ARG ROMERO_BRANCH_USER=ome
+ARG ROMERO_BRANCH=master
+
+# R-kernel and R-OMERO prerequisites
+ADD environment-r-omero.yml .setup/
+RUN conda env update -n r-omero -q -f .setup/environment-r-omero.yml && \
+    /opt/conda/envs/r-omero/bin/Rscript -e "IRkernel::installspec(displayname='OMERO R')"
+
+USER root
+RUN mkdir /opt/romero /opt/omero && \
+    fix-permissions /opt/romero /opt/omero
+# R requires these two packages at runtime
+RUN apt-get install -y -q \
+    libxrender1 \
+    libsm6
+USER $NB_UID
+
+# build/install rOMERO
+ENV _JAVA_OPTIONS="-Xss2560k -Xmx2g"
+RUN cd /opt/romero && \
+    curl -sf https://raw.githubusercontent.com/ome/rOMERO-gateway/master/install.R --output install.R && \
+    bash -c "source activate r-omero && Rscript install.R --user=$ROMERO_BRANCH_USER --branch=$ROMERO_BRANCH --quiet"
+
+ENV OMERO_LIBS_DOWNLOAD=TRUE
+RUN bash -c "source activate r-omero && echo \"library('romero.gateway')\" | R --no-save"
+
+# OMERO full CLI
+# This currently uses the python2 environment, should we move it to its own?
+ARG OMERO_VERSION=5.4.10
+RUN cd /opt/omero && \
+    /opt/conda/envs/python2/bin/pip install -q omego && \
+    /opt/conda/envs/python2/bin/omego download -q --sym OMERO.server server --release $OMERO_VERSION && \
+    rm OMERO.server-*.zip
+ADD docker/omero-bin.sh /usr/local/bin/omero
+
+# Clone the source git repo into notebooks (keep this at the end of the file)
+COPY --chown=1000:100 . notebooks
+

--- a/jupyter/Dockerfile
+++ b/jupyter/Dockerfile
@@ -2,6 +2,7 @@ FROM imagedata/jupyter-docker:0.9.0
 MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 
 # The branch to build the romero.gateway from
+ARG ROMERO_VERSION=
 ARG ROMERO_BRANCH_USER=ome
 ARG ROMERO_BRANCH=master
 
@@ -23,20 +24,7 @@ USER $NB_UID
 ENV _JAVA_OPTIONS="-Xss2560k -Xmx2g"
 RUN cd /opt/romero && \
     curl -sf https://raw.githubusercontent.com/ome/rOMERO-gateway/master/install.R --output install.R && \
-    bash -c "source activate r-omero && Rscript install.R --user=$ROMERO_BRANCH_USER --branch=$ROMERO_BRANCH --quiet"
+    bash -c "source activate r-omero && Rscript install.R --version=ROMERO_VERSION --user=$ROMERO_BRANCH_USER --branch=$ROMERO_BRANCH --quiet"
 
 ENV OMERO_LIBS_DOWNLOAD=TRUE
 RUN bash -c "source activate r-omero && echo \"library('romero.gateway')\" | R --no-save"
-
-# OMERO full CLI
-# This currently uses the python2 environment, should we move it to its own?
-ARG OMERO_VERSION=5.4.10
-RUN cd /opt/omero && \
-    /opt/conda/envs/python2/bin/pip install -q omego && \
-    /opt/conda/envs/python2/bin/omego download -q --sym OMERO.server server --release $OMERO_VERSION && \
-    rm OMERO.server-*.zip
-ADD docker/omero-bin.sh /usr/local/bin/omero
-
-# Clone the source git repo into notebooks (keep this at the end of the file)
-COPY --chown=1000:100 . notebooks
-

--- a/jupyter/Dockerfile
+++ b/jupyter/Dockerfile
@@ -5,6 +5,7 @@ MAINTAINER ome-devel@lists.openmicroscopy.org.uk
 ARG ROMERO_VERSION=
 ARG ROMERO_BRANCH_USER=ome
 ARG ROMERO_BRANCH=master
+ARG INSTALL_SCRIPT_URL=https://raw.githubusercontent.com/ome/rOMERO-gateway/master/install.R
 
 # R-kernel and R-OMERO prerequisites
 ADD environment-r-omero.yml .setup/
@@ -23,7 +24,7 @@ USER $NB_UID
 # build/install rOMERO
 ENV _JAVA_OPTIONS="-Xss2560k -Xmx2g"
 RUN cd /opt/romero && \
-    curl -sf https://raw.githubusercontent.com/ome/rOMERO-gateway/master/install.R --output install.R
+    curl -sf $INSTALL_SCRIPT_URL --output install.R
 RUN if [ -z ${ROMERO_VERSION} ]; then \
     bash -c "source activate r-omero && Rscript /opt/romero/install.R --user=$ROMERO_BRANCH_USER --branch=$ROMERO_BRANCH --quiet"; else \
     bash -c "source activate r-omero && Rscript /opt/romero/install.R --version=$ROMERO_VERSION --quiet"; fi

--- a/jupyter/Get_Started.ipynb
+++ b/jupyter/Get_Started.ipynb
@@ -14,6 +14,7 @@
    "outputs": [],
    "source": [
     "library(romero.gateway)\n",
+    "library(EBImage) # for displaying an image (also useful for image analysis!)\n",
     "\n",
     "# Connect to server\n",
     "server <- OMEROServer(host = 'SERVER_NAME', username='USER_NAME', password='PASSWORD', port= as.integer(4064))\n",

--- a/jupyter/Get_Started.ipynb
+++ b/jupyter/Get_Started.ipynb
@@ -1,0 +1,81 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load library and connect to an OMERO server"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "library(romero.gateway)\n",
+    "\n",
+    "# Connect to server\n",
+    "server <- OMEROServer(host = 'SERVER_NAME', username='USER_NAME', password='PASSWORD', port= as.integer(4064))\n",
+    "server <- connect(server)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Perform some tasks"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load an image\n",
+    "imageId <- IMAGE_ID # Replace with an actual image id\n",
+    "image <- loadObject(server, \"ImageData\", imageId)\n",
+    "pixels <- getPixelValues(image, 1, 1, 1)\n",
+    "\n",
+    "# Use EBImage to display it\n",
+    "ebimage <- EBImage::Image(data = pixels, colormode = 'Grayscale')\n",
+    "ebimage <- normalize(ebimage)\n",
+    "EBImage::display(ebimage)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Disconnect again"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "disconnect(server)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "OMERO R",
+   "language": "R",
+   "name": "ir"
+  },
+  "language_info": {
+   "codemirror_mode": "r",
+   "file_extension": ".r",
+   "mimetype": "text/x-r-source",
+   "name": "R",
+   "pygments_lexer": "r",
+   "version": "3.5.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/jupyter/README.md
+++ b/jupyter/README.md
@@ -12,8 +12,8 @@ docker build -t romero .
 
 Note: If you want to build a specific version or branch use:
 ```
-docker build --build-arg ROMERO_VERSION=0.4.5
-docker build --build-arg ROMERO_BRANCH_USER=ome --build-arg ROMERO_BRANCH=master
+docker build --build-arg ROMERO_VERSION=0.4.5 .
+docker build --build-arg ROMERO_BRANCH_USER=ome --build-arg ROMERO_BRANCH=master .
 ```
 
 Run the docker image:

--- a/jupyter/README.md
+++ b/jupyter/README.md
@@ -15,7 +15,8 @@ Run the docker image:
 docker run -it -p 8888:8888 romero
 ```
 
-Go to the respective URL in your browser and create a new "OMERO R" notebook!
+Go to the respective URL in your browser and open the `Get_Started` notebook in `notebooks`,
+or create a new 'OMERO R' notebook from scratch!
 
 Notes:
 - If you want to build a specific version or branch use:

--- a/jupyter/README.md
+++ b/jupyter/README.md
@@ -5,12 +5,20 @@ Spin up a Jupyter server with Docker:
 
 CD into this directory and run:
 ```
-docker build .
+docker build -t romero .
 
 ```
+(this will build the romero.gateway from the current ome/master branch)
 
-Note: If you want to build a specific version or branch:
+Note: If you want to build a specific version or branch use:
 ```
 docker build --build-arg ROMERO_VERSION=0.4.5
-docker build --build-arg ROMERO_BRANCH_USER=ome ROMERO_BRANCH=master
+docker build --build-arg ROMERO_BRANCH_USER=ome --build-arg ROMERO_BRANCH=master
 ```
+
+Run the docker image:
+```
+docker run -it -p 8888:8888 romero
+```
+
+Go to the respective URL in your browser and create a new "OMERO R" notebook!

--- a/jupyter/README.md
+++ b/jupyter/README.md
@@ -1,0 +1,16 @@
+Jupyter server
+==============
+
+Spin up a Jupyter server with Docker:
+
+CD into this directory and run:
+```
+docker build .
+
+```
+
+Note: If you want to build a specific version or branch:
+```
+docker build --build-arg ROMERO_VERSION=0.4.5
+docker build --build-arg ROMERO_BRANCH_USER=ome ROMERO_BRANCH=master
+```

--- a/jupyter/README.md
+++ b/jupyter/README.md
@@ -10,15 +10,18 @@ docker build -t romero .
 ```
 (this will build the romero.gateway from the current ome/master branch)
 
-Note: If you want to build a specific version or branch use:
-```
-docker build --build-arg ROMERO_VERSION=0.4.5 .
-docker build --build-arg ROMERO_BRANCH_USER=ome --build-arg ROMERO_BRANCH=master .
-```
-
 Run the docker image:
 ```
 docker run -it -p 8888:8888 romero
 ```
 
 Go to the respective URL in your browser and create a new "OMERO R" notebook!
+
+Notes:
+- If you want to build a specific version or branch use:
+  ```
+  docker build --build-arg ROMERO_VERSION=0.4.5 .
+  docker build --build-arg ROMERO_BRANCH_USER=ome --build-arg ROMERO_BRANCH=master .
+  ```
+- The Dockerfile uses the  [install.R](../install.R) script from the master branch.
+  You can specify a different script with the `INSTALL_SCRIPT_URL` parameter.

--- a/jupyter/environment-r-omero.yml
+++ b/jupyter/environment-r-omero.yml
@@ -1,3 +1,5 @@
+# Install some common, useful R packages. These are
+# not all strictly necessary for romero.gateway.
 channels:
 - bioconda
 - conda-forge

--- a/jupyter/environment-r-omero.yml
+++ b/jupyter/environment-r-omero.yml
@@ -1,0 +1,23 @@
+channels:
+- bioconda
+- conda-forge
+- defaults
+dependencies:
+- bioconductor-ebimage
+- openjdk=8.0.*
+- r-assertthat
+- r-base=3.5.*
+- r-devtools
+- r-git2r
+- r-httr
+- r-irdisplay
+- r-irkernel
+- r-jpeg
+- r-repr
+- r-rjava
+- r-roxygen2
+- r-testthat
+- r-tidyverse
+- r-xml2
+- r-getpass
+prefix: /opt/conda/envs/r-omero


### PR DESCRIPTION
Add a Dockerfile to spin up a Juypiter server with R and customizable version/branch of `romero.gateway`. This should make it much easier to quickly test snippets, review PRs, etc.

Based on https://github.com/ome/training-notebooks but without installing python, cellprofiler, etc.

/cc @jburel 

**Test:**
What it says in the README.md: 
`docker build .`
`docker run -it -p 8888:8888 romero`
