### PR TITLE
Set namespace of attached dataframe

### DIFF
--- a/R/OMERO.R
+++ b/R/OMERO.R
@@ -107,6 +107,7 @@ setGeneric(
 #' @param omero The OME object
 #' @param df The dataframe
 #' @param name An optional name
+#' @param ns An optional namespace for the file annotation
 #' @return The OME object
 #' @export attachDataframe
 #' @exportMethod attachDataframe
@@ -116,7 +117,7 @@ setGeneric(
 #' }
 setGeneric(
   name = "attachDataframe",
-  def = function(omero, df, name="R Dataframe")
+  def = function(omero, df, name="R Dataframe", ns=NA)
   {
     standardGeneric("attachDataframe")
   }
@@ -340,13 +341,14 @@ setMethod(
 #' @param omero The OME object
 #' @param df The dataframe
 #' @param name An optional name
+#' @param ns An optional namespace for the file annotation
 #' @return The OME object
 #' @export attachDataframe
 #' @exportMethod attachDataframe
 setMethod(
   f = "attachDataframe",
   signature = "OMERO",
-  definition = function(omero, df, name)
+  definition = function(omero, df, name, ns=NA)
   {
    if(!is.data.frame(df)) {
      return(FALSE)
@@ -402,7 +404,10 @@ setMethod(
     ctx <- getContext(server)
     fac <- gateway$getFacility(TablesFacility$class)
     
-    tabledata <- fac$addTable(ctx, omero@dataobject, name, table)
+    if (!is.na(ns))
+      tabledata <- fac$addTable(ctx, omero@dataobject, name, as.character(ns), table)
+    else
+      tabledata <- fac$addTable(ctx, omero@dataobject, name, table)
     
     return(omero)
   }

--- a/examples/AddTable.R
+++ b/examples/AddTable.R
@@ -19,6 +19,10 @@ server <- connect(server)
 datasetId <- 1
 dataset <- loadObject(server, "DatasetData", datasetId)
 
+# Create a dataframe with one row per image, like:
+# Image, SomeValue, AnotherValue
+# 1, 'Some value', 'Another Value'
+# ...
 imgIds <- c()
 values1 <- c()
 values2 <- c()
@@ -28,5 +32,10 @@ for (img in getImages(dataset)) {
   values2 <- c(values2, paste("Another value for image",img@dataobject$getName()))
 }
 
+# Attach it as dataframe with namespace 'openmicroscopy.org/omero/bulk_annotations'
+# to make it available to OMERO.web
 df <- data.frame(Image = imgIds, SomeValue = values1, AnotherValue = values2)
 attachDataframe(dataset, df, "Example data", ns = "openmicroscopy.org/omero/bulk_annotations")
+
+# Go to OMERO.web client, select an image and you should see its values
+# in the 'Tables' tab.

--- a/examples/AddTable.R
+++ b/examples/AddTable.R
@@ -1,0 +1,32 @@
+###
+# Add a dataframe which is accessible to the OMERO.web client.
+#
+# This example uses the attachDataframe method again (like the AddData.R example),
+# but this time an 'Image' column with the image Ids is added and the dataframe 
+# gets attached to a dataset with the particular namespace 
+# 'openmicroscopy.org/omero/bulk_annotations'. This way the entries in the dataframe
+# will be picked up by the OMERO.web client and shown on the 'Tables' tab of the 
+# images.
+###
+
+library(romero.gateway)
+
+# Connect to server
+server <- OMEROServer(host = "localhost", username = "xx", password = "xx", port = as.integer(4064))server <- connect(server)
+server <- connect(server)
+
+# Load a dataset
+datasetId <- 1
+dataset <- loadObject(server, "DatasetData", datasetId)
+
+imgIds <- c()
+values1 <- c()
+values2 <- c()
+for (img in getImages(dataset)) {
+  imgIds <- c(imgIds, getOMEROID(img))
+  values1 <- c(values1, paste("Some value for image",img@dataobject$getName()))
+  values2 <- c(values2, paste("Another value for image",img@dataobject$getName()))
+}
+
+df <- data.frame(Image = imgIds, SomeValue = values1, AnotherValue = values2)
+attachDataframe(dataset, df, "Example data", ns = "openmicroscopy.org/omero/bulk_annotations")

--- a/man/attachDataframe-OMERO-method.Rd
+++ b/man/attachDataframe-OMERO-method.Rd
@@ -5,7 +5,8 @@
 \alias{attachDataframe,OMERO-method}
 \title{Attaches a dataframe to an OME object}
 \usage{
-\S4method{attachDataframe}{OMERO}(omero, df, name = "R Dataframe")
+\S4method{attachDataframe}{OMERO}(omero, df, name = "R Dataframe",
+  ns = NA)
 }
 \arguments{
 \item{omero}{The OME object}
@@ -13,6 +14,8 @@
 \item{df}{The dataframe}
 
 \item{name}{An optional name}
+
+\item{ns}{An optional namespace for the file annotation}
 }
 \value{
 The OME object

--- a/man/attachDataframe.Rd
+++ b/man/attachDataframe.Rd
@@ -4,7 +4,7 @@
 \alias{attachDataframe}
 \title{Attaches a dataframe to an OME object}
 \usage{
-attachDataframe(omero, df, name = "R Dataframe")
+attachDataframe(omero, df, name = "R Dataframe", ns = NA)
 }
 \arguments{
 \item{omero}{The OME object}
@@ -12,6 +12,8 @@ attachDataframe(omero, df, name = "R Dataframe")
 \item{df}{The dataframe}
 
 \item{name}{An optional name}
+
+\item{ns}{An optional namespace for the file annotation}
 }
 \value{
 The OME object


### PR DESCRIPTION
Just adds another parameter to `attachDataframe` method to allow to set the namespace of the file annotation of the omero.table.

This would prevent some horrible workarounds like https://github.com/dominikl/shapeR/blob/master/example.R#L29 .

Requires: https://github.com/ome/omero-gateway-java/pull/18

## Test
Build the jupyter docker from the snoopy build:
`docker build -t romero --build-arg OMERO_LIBS_DOWNLOAD='https://merge-ci.openmicroscopy.org/jenkins/job/OMERO-build/130' --build-arg ROMERO_BRANCH_USER=snoopycrimecop --build-arg ROMERO_BRANCH=master_merge_daily .`
Use the 'Get Started' notebook. Add this block after the "Image display" bit:
```
library(datasets)
data("iris")
data.frame(iris)
attachDataframe(image, iris, "Iris Example dataset", ns = "test namespace")
```
Check that the `Iris Example dataset` dataframe is attached as OMERO.table on the image and has namespace `test namespace`.