### PR TITLE
Add possibility to use merge-ci java libs

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -24,13 +24,21 @@
     getLibs <- Sys.getenv("OMERO_LIBS_DOWNLOAD", unset = NA)
     if (!is.na(getLibs) && startsWith(tolower(getLibs), 'http')) {
       git_info <- GET(getLibs)
-      git_info <- content(git_info, "text")
-      ex <- "(OMERO\\.java-\\S+\\.zip)"
-      r <- gregexpr(ex, git_info)
-      res <- regmatches(git_info, r)
-      zipFile <- res[[1]][[2]]
-      baseURL <- "https://merge-ci.openmicroscopy.org/jenkins/job/OMERO-build/lastBuild/artifact/src/target"
-      acc <- 'y'
+      status <- status_code(git_info)
+      if (status != 200) {
+        packageStartupMessage("Request failed. ", getLibs, " returned ", status)
+        acc <- 'n'
+      } else {
+        git_info <- content(git_info, "text")
+        ex <- "(OMERO\\.java-\\S+\\.zip)"
+        r <- gregexpr(ex, git_info)
+        res <- regmatches(git_info, r)
+        zipFile <- res[[1]][[2]]
+        baseURL <- getLibs
+        if (endsWith(getLibs, '/'))
+          baseURL <- substr(baseURL, 1, nchar(baseURL)-1)
+        acc <- 'y'
+      }
     }
     else if (!is.na(getLibs) && as.logical(getLibs) == TRUE) {
       acc <- 'y'

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -23,6 +23,8 @@
     
     getLibs <- Sys.getenv("OMERO_LIBS_DOWNLOAD", unset = NA)
     if (!is.na(getLibs) && startsWith(tolower(getLibs), 'http')) {
+      # Allows using Java libs from merge-ci builds, e.g.
+      # https://merge-ci.openmicroscopy.org/jenkins/job/OMERO-build/lastBuild/
       git_info <- GET(getLibs)
       status <- status_code(git_info)
       if (status != 200) {
@@ -30,13 +32,15 @@
         acc <- 'n'
       } else {
         git_info <- content(git_info, "text")
-        ex <- "(OMERO\\.java-\\S+\\.zip)"
+        ex <- ">(OMERO\\.java-\\S+\\.zip)<"
         r <- gregexpr(ex, git_info)
         res <- regmatches(git_info, r)
-        zipFile <- res[[1]][[2]]
+        zipFile <- substr(res[[1]], 2, nchar(res[[1]])-1)
         baseURL <- getLibs
         if (endsWith(getLibs, '/'))
-          baseURL <- substr(baseURL, 1, nchar(baseURL)-1)
+          baseURL <- paste(baseURL, "artifact/src/target", sep = '')
+        else
+          baseURL <- paste(baseURL, "artifact/src/target", sep = '/') 
         acc <- 'y'
       }
     }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -22,10 +22,8 @@
     zipFile <- 'OMERO.java.zip'
     
     getLibs <- Sys.getenv("OMERO_LIBS_DOWNLOAD", unset = NA)
-    if (!is.na(getLibs) && getLibs != 'merge' && as.logical(getLibs) == TRUE) {
-      acc <- 'y'
-    } else if (!is.na(getLibs) && getLibs == 'merge') {
-      git_info <- GET('https://merge-ci.openmicroscopy.org/jenkins/job/OMERO-build/lastBuild/artifact/src/target/')
+    if (!is.na(getLibs) && startsWith(tolower(getLibs), 'http')) {
+      git_info <- GET(getLibs)
       git_info <- content(git_info, "text")
       ex <- "(OMERO\\.java-\\S+\\.zip)"
       r <- gregexpr(ex, git_info)
@@ -33,8 +31,11 @@
       zipFile <- res[[1]][[2]]
       baseURL <- "https://merge-ci.openmicroscopy.org/jenkins/job/OMERO-build/lastBuild/artifact/src/target"
       acc <- 'y'
-    }else {
-      packageStartupMessage('Have to download OMERO Java libraries ', baseURL, '/', zipFile, '\nProceed? [y/n]')
+    }
+    else if (!is.na(getLibs) && as.logical(getLibs) == TRUE) {
+      acc <- 'y'
+    } else {
+      packageStartupMessage('Have to download OMERO Java libraries from downloads.openmicroscopy.org.\nProceed? [y/n]')
       acc <- readLines(con = stdin(), n=1, ok=TRUE)
     }
     

--- a/jupyter/Dockerfile
+++ b/jupyter/Dockerfile
@@ -6,6 +6,7 @@ ARG ROMERO_VERSION=
 ARG ROMERO_BRANCH_USER=ome
 ARG ROMERO_BRANCH=master
 ARG INSTALL_SCRIPT_URL=https://raw.githubusercontent.com/ome/rOMERO-gateway/master/install.R
+ARG OMERO_LIBS_DOWNLOAD=TRUE
 
 USER root
 RUN apt-get update -y && \
@@ -30,13 +31,14 @@ RUN conda env update -n r-omero -q -f .setup/environment-r-omero.yml && \
 
 # build/install rOMERO
 ENV _JAVA_OPTIONS="-Xss2560k -Xmx2g"
+
 RUN cd /opt/romero && \
     curl -sf $INSTALL_SCRIPT_URL --output install.R
 RUN if [ -z ${ROMERO_VERSION} ]; then \
     bash -c "source activate r-omero && Rscript /opt/romero/install.R --user=$ROMERO_BRANCH_USER --branch=$ROMERO_BRANCH --quiet"; else \
     bash -c "source activate r-omero && Rscript /opt/romero/install.R --version=$ROMERO_VERSION --quiet"; fi
 
-ENV OMERO_LIBS_DOWNLOAD=TRUE
+ENV OMERO_LIBS_DOWNLOAD=${OMERO_LIBS_DOWNLOAD}
 RUN bash -c "source activate r-omero && echo \"library('romero.gateway')\" | R --no-save"
 
 COPY --chown=1000:100 Get_Started.ipynb notebooks/


### PR DESCRIPTION
With this PR it would be possible to tell the `romero.gateway` package to use the Java libs from merge-ci when loaded the first time using the `OMERO_LIBS_DOWNLOAD` environment variable.
By default (if no `OMERO_LIBS_DOWNLOAD` is set) the user has to confirm to download the Java libs from the release page. For automatic installation without user interaction you can set `OMERO_LIBS_DOWNLOAD` to `TRUE` in which case the OMERO.java.zip is downloaded automatically. With this PR you can also set `OMERO_LIBS_DOWNLOAD` to a URL pointing to a CI builds page (e.g. `https://merge-ci.openmicroscopy.org/jenkins/job/OMERO-build/lastBuild`). Then the OMERO.java.zip is downloaded from there.

This in combination with the jupyter docker would make it easier testing romero.gateway PRs which also depend on open PRs against the java-gateway (or even further downstream).

## Test (with jupyter docker)
It does print out the download location on stdout, but unfortunately in the docker build process you don't see it. But you see it if it fails:
```
﻿cd jupyter
# wrong URL. build 10000 doesn't exist
docker build -t romero --build-arg OMERO_LIBS_DOWNLOAD='https://merge-ci.openmicroscopy.org/jenkins/job/OMERO-build/10000' --build-arg ROMERO_BRANCH_USER=dominikl --build-arg ROMERO_BRANCH=merge_ci .
```
You should see something like `Request failed .... returned 404` in the output.

```
# correct URL, build 114 does exist
docker build -t romero --build-arg OMERO_LIBS_DOWNLOAD='https://merge-ci.openmicroscopy.org/jenkins/job/OMERO-build/114' --build-arg ROMERO_BRANCH_USER=dominikl --build-arg ROMERO_BRANCH=merge_ci .
```
This should work.
