### PR TITLE
Fix print pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+0.4.10 (October 2020)
+---------------------
+
+- fix issue that login password could accidentally be printed
+  in console
+
 0.4.9 (February 2020)
 ---------------------
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: romero.gateway
 Type: Package
-Version: 0.4.9
-Date: 2020-02-26
+Version: 0.4.10
+Date: 2020-10-02
 Title: OMERO R Gateway
 Description: R Wrapper around the OMERO Java Gateway, which
   enables access to an OMERO server within R.

--- a/R/OMEROServer.R
+++ b/R/OMEROServer.R
@@ -72,6 +72,8 @@ setGeneric(name="connect",
 )
 
 #' Disconnect from an OMERO server
+#' Note: You cannot reconnect using the same OMEROServer instance,
+#' you have to create a new OMEROServer!
 #' 
 #' @param server The server
 #' @return The server in "disconnected" state (if successful)
@@ -417,11 +419,15 @@ setMethod(f="connect",
             if (is.null(server@ctx))
               server@ctx <- new (SecurityContext, .jlong(user$getGroupId()))
             
+            server@password <- "***"
+            
             return(server)
           }
 )
 
 #' Disconnect from an OMERO server
+#' Note: You cannot reconnect using the same OMEROServer instance,
+#' you have to create a new OMEROServer!
 #' 
 #' @param server The server
 #' @return The server in "disconnected" state (if successful)


### PR DESCRIPTION
If you create an OMEROServer object and print it out the whole content is dumped to the console including the login password. With this PR the password will be set to `***` after successful login.
Also updated Changelog and Description in case we want to push a release?
/cc @jburel 
