### PR TITLE
Use global because base env is locked since 4.1.0

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -87,9 +87,12 @@
   .jinit(classpath = dir(omeroLibs, full.names=TRUE ))
 
   # Unfortunately have to add this stuff to base env
-  # because romero.gateway env is locked
-  env <- baseenv()
-  
+  # because romero.gateway env is locked.
+  # Update: With R 4.1.0 the base env is locked too,
+  # have to use global env instead.
+  # Todo: Remove all global exports completely.
+  env <- globalenv()
+
   # Genereal Java classes
   env$Collection <- J("java.util.Collection")
   env$Collections <- J("java.util.Collections")


### PR DESCRIPTION
Exports into the base env are locked since R 4.1.0. Use the global env instead for now. I know this is really bad practice and should be removed in future. As far as I remember this is only done for conveniece anyway, and could be moved into the methods directly. But for now this PR would fix the issue https://github.com/ome/rOMERO-gateway/issues/94  (thanks @c5creative for the hint!).